### PR TITLE
fix `No transaction in context.`

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -706,7 +706,7 @@ abstract class VendorDialect(
     override fun resetCaches() {
         _allTableNames = null
         columnConstraintsCache.clear()
-        TransactionManager.current().db.metadata { cleanCache() }
+        TransactionManager.defaultDatabase?.metadata { cleanCache() } ?: error("Database required")
     }
 
     override fun resetSchemaCaches() {


### PR DESCRIPTION
resetCaches called without any prior db calls results in `No transaction in context` message because currentThreadManager is not set